### PR TITLE
Monitor arbitrage for profit threshold

### DIFF
--- a/THRESHOLD_FEATURE.md
+++ b/THRESHOLD_FEATURE.md
@@ -1,0 +1,85 @@
+# Threshold-Based Arbitrage Feature
+
+This feature allows you to set a minimum profit threshold for arbitrage execution. The process will continuously monitor the expected profit and only execute the arbitrage when the profit meets or exceeds the specified threshold.
+
+## Usage
+
+### Basic Usage
+
+```bash
+./distribute --threshold 0.01 --minipool <minipool-address>
+```
+
+This will:
+- Check the expected profit every minute (default interval)
+- Wait until the profit reaches at least 0.01 ETH
+- Execute the arbitrage when the threshold is met
+
+### Advanced Usage
+
+```bash
+./distribute --threshold 0.005 --check-interval 30s --minipool <minipool-address> --protocol best
+```
+
+This will:
+- Check profit every 30 seconds
+- Wait for profit to reach 0.005 ETH
+- Use the best protocol (Uniswap or Paraswap)
+- Execute when threshold is met
+
+## Flags
+
+### --threshold
+- **Type**: string
+- **Description**: Minimum profit threshold in ETH (e.g., 0.01)
+- **Example**: `--threshold 0.01`
+
+### --check-interval
+- **Type**: duration
+- **Default**: 1m (1 minute)
+- **Description**: Interval between profit checks
+- **Examples**: 
+  - `--check-interval 30s` (30 seconds)
+  - `--check-interval 2m` (2 minutes)
+  - `--check-interval 1h` (1 hour)
+
+## How It Works
+
+1. **Initialization**: The process sets up the connection and validates inputs
+2. **Profit Monitoring**: Every `check-interval`, the process:
+   - Calculates current expected profit from arbitrage
+   - Compares it against the threshold
+   - Logs the current profit vs threshold
+3. **Execution**: When profit meets or exceeds the threshold:
+   - Logs that threshold is met
+   - Executes the normal arbitrage process
+   - Sends the bundle to Flashbots
+
+## Example Output
+
+```
+Waiting for profit to reach threshold of 0.010000 ETH...
+Checking every 1m0s...
+
+Current expected profit: 0.005000 ETH (threshold: 0.010000 ETH)
+Current expected profit: 0.007500 ETH (threshold: 0.010000 ETH)
+Current expected profit: 0.012000 ETH (threshold: 0.010000 ETH)
+Profit threshold met! Expected profit: 0.012000 ETH
+
+[normal arbitrage execution continues...]
+```
+
+## Use Cases
+
+1. **Profit Optimization**: Wait for better market conditions
+2. **Risk Management**: Only execute when profit justifies gas costs
+3. **Automated Trading**: Set and forget arbitrage with profit targets
+4. **Market Timing**: Avoid executing during unfavorable conditions
+
+## Notes
+
+- The process will run indefinitely until the threshold is met or the process is interrupted
+- Use Ctrl+C to stop the process if needed
+- All existing flags (--protocol, --receiver, etc.) work with threshold mode
+- The profit calculation includes gas fees and uses the same logic as normal execution
+- Threshold values are in ETH (not wei) for user convenience

--- a/arbitrage/types.go
+++ b/arbitrage/types.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -36,6 +37,8 @@ type DataIn struct {
 	Ratelimit                       int
 	Protocol                        Protocol
 	NetworkId                       uint64
+	Threshold                       *big.Int
+	CheckInterval                   time.Duration
 }
 
 type UniswapArbitrage struct {

--- a/test_threshold.sh
+++ b/test_threshold.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+echo "Testing threshold functionality..."
+echo "This script demonstrates the new --threshold flag for the distribute command."
+echo ""
+
+# Test with a very high threshold to see the waiting behavior
+echo "Testing with threshold of 1.0 ETH (very high, should wait indefinitely):"
+echo "Command: ./distribute --threshold 1.0 --check-interval 10s --minipool 0x1234567890123456789012345678901234567890 --dry-run"
+echo ""
+
+# Note: This is just for demonstration - in a real scenario you'd need valid minipool addresses
+echo "Note: This is a demonstration. In a real scenario, you would need:"
+echo "1. Valid minipool addresses"
+echo "2. Proper RPC connection"
+echo "3. Valid node configuration"
+echo ""
+echo "The threshold functionality will:"
+echo "- Check profit every 10 seconds (or specified interval)"
+echo "- Wait until profit reaches 1.0 ETH"
+echo "- Execute the arbitrage when threshold is met"
+echo ""
+echo "To use in production:"
+echo "./distribute --threshold 0.01 --check-interval 1m --minipool <your-minipool-address>"
+echo ""
+echo "This will wait until profit reaches 0.01 ETH before executing."


### PR DESCRIPTION
Add `--threshold` and `--check-interval` flags to `./distribute` to enable profit-based arbitrage execution.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4f9325b-3506-4579-8d78-03eb9f214528">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4f9325b-3506-4579-8d78-03eb9f214528">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

