### PR TITLE
Monitor arbitrage for profit threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ When **exiting minipools** or **claiming ETH**, it is vital to check for arbitra
 
 The core objective is to leverage **distribute** calls in combination with **rETH burn** to capture potential arbitrage gains. This tool can also facilitate a **flashloan** for users who don't already hold rETH but want to capitalize on the arbitrage.
 
+**Profit Threshold Monitoring**: The tool now supports waiting for optimal arbitrage conditions using the `--threshold` flag. When set, the tool will continuously monitor the expected profit and only execute the arbitrage transaction when the profit meets or exceeds your specified threshold. This allows you to wait for more favorable market conditions before executing.
+
 If you prefer not to run this CLI tool on your validator machine alongside the smartnode daemon—or if you don't have access to the smartnode (for example, when using a service like [Allnodes](https://www.allnodes.com/)) — you can use the `--rpc=...` flag and provide your node operator private key via `--node-private-key`. You can also use your Withdrawal Address instead, depending on what best suits your situation.
 
 If you encounter any issues while using the tool, please open a GitHub issue so we can investigate and address it.
@@ -521,6 +523,24 @@ Notice: When using a free RPC connection, consider setting a rate limit to avoid
   ./distribute --ratelimit=250
   ```
 
+- **Flag**: `--threshold`
+  **Type**: float64  (ETH amount)
+  **Default**: `0`  
+  **Description**: Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until the threshold is met before executing the arbitrage transaction. When set to 0, the tool executes immediately without monitoring.
+  **Example**: Wait until expected profit reaches 0.01 ETH before executing.
+  ```bash
+  ./distribute --threshold=0.01 --minipools=0xABC123...
+  ```
+
+- **Flag**: `--monitor-interval`
+  **Type**: int  (seconds)
+  **Default**: `60`  
+  **Description**: Interval in seconds to check profit when using `--threshold`. This controls how frequently the tool recalculates the expected profit to compare against the threshold.
+  **Example**: Check profit every 30 seconds.
+  ```bash
+  ./distribute --threshold=0.01 --monitor-interval=30 --minipools=0xABC123...
+  ```
+
 ---
 
 ## Combining Flags
@@ -532,6 +552,14 @@ You can combine multiple flags in a single command. For example:
 ```
 
 This example enables debug logs, uses local rETH and specifies multiple minipools.
+
+For profit threshold monitoring:
+
+```bash
+./distribute --threshold=0.02 --monitor-interval=30 --minipools=0xABC123...,0xDEF456... --skip-confirmation
+```
+
+This example waits until the expected profit reaches 0.02 ETH, checking every 30 seconds, and automatically executes without user confirmation once the threshold is met.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -524,10 +524,10 @@ Notice: When using a free RPC connection, consider setting a rate limit to avoid
   ```
 
 - **Flag**: `--threshold`
-  **Type**: float64  (ETH amount)
+  **Type**: float64  (ETH amount per minipool)
   **Default**: `0`  
-  **Description**: Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until the threshold is met before executing the arbitrage transaction. When set to 0, the tool executes immediately without monitoring.
-  **Example**: Wait until expected profit reaches 0.01 ETH before executing.
+  **Description**: Minimum profit threshold in ETH per minipool. If set, the tool will monitor profit and wait until the per-minipool profit meets the threshold before executing the arbitrage transaction. When set to 0, the tool executes immediately without monitoring.
+  **Example**: Wait until expected profit reaches 0.01 ETH per minipool before executing.
   ```bash
   ./distribute --threshold=0.01 --minipools=0xABC123...
   ```
@@ -559,7 +559,7 @@ For profit threshold monitoring:
 ./distribute --threshold=0.02 --monitor-interval=30 --minipools=0xABC123...,0xDEF456... --skip-confirmation
 ```
 
-This example waits until the expected profit reaches 0.02 ETH, checking every 30 seconds, and automatically executes without user confirmation once the threshold is met.
+This example waits until the expected profit reaches 0.02 ETH per minipool (0.04 ETH total for 2 minipools), checking every 30 seconds, and automatically executes without user confirmation once the threshold is met.
 
 ---
 

--- a/arbitrage/types.go
+++ b/arbitrage/types.go
@@ -36,6 +36,8 @@ type DataIn struct {
 	Ratelimit                       int
 	Protocol                        Protocol
 	NetworkId                       uint64
+	Threshold                       float64
+	MonitorInterval                 int
 }
 
 type UniswapArbitrage struct {

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -66,7 +66,7 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 		"Private key for the node address used as caller. This can be used if the script should not use the RP daemon to sign transactions. (e.g. when using Allnode)",
 	)
 	ratelimitFlag := flag.Int("ratelimit", 0, "Rate limit in milliseconds between each minipool distribution call. (default: 0)")
-	thresholdFlag := flag.Float64("threshold", 0, "Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until threshold is met before executing. (default: 0 - execute immediately)")
+	thresholdFlag := flag.Float64("threshold", 0, "Minimum profit threshold in ETH per minipool. If set, the tool will monitor profit and wait until per-minipool threshold is met before executing. (default: 0 - execute immediately)")
 	monitorIntervalFlag := flag.Int("monitor-interval", 60, "Interval in seconds to check profit when using --threshold. (default: 60 seconds)")
 
 	flag.Parse()

--- a/cmd/distribute/distribute.go
+++ b/cmd/distribute/distribute.go
@@ -66,6 +66,8 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 		"Private key for the node address used as caller. This can be used if the script should not use the RP daemon to sign transactions. (e.g. when using Allnode)",
 	)
 	ratelimitFlag := flag.Int("ratelimit", 0, "Rate limit in milliseconds between each minipool distribution call. (default: 0)")
+	thresholdFlag := flag.Float64("threshold", 0, "Minimum profit threshold in ETH. If set, the tool will monitor profit and wait until threshold is met before executing. (default: 0 - execute immediately)")
+	monitorIntervalFlag := flag.Int("monitor-interval", 60, "Interval in seconds to check profit when using --threshold. (default: 60 seconds)")
 
 	flag.Parse()
 
@@ -241,6 +243,11 @@ func parseInput(ctx context.Context, logger *slog.Logger) (data *arbitrage.DataI
 
 	data.Ratelimit = *ratelimitFlag
 	logger.Debug("ratelimit", slog.Int("ratelimit", data.Ratelimit))
+
+	data.Threshold = *thresholdFlag
+	data.MonitorInterval = *monitorIntervalFlag
+	logger.Debug("threshold", slog.Float64("threshold", data.Threshold))
+	logger.Debug("monitorInterval", slog.Int("monitorInterval", data.MonitorInterval))
 
 	return data, nil
 }


### PR DESCRIPTION
Add `--threshold` and `--monitor-interval` flags to `./distribute` to enable waiting for a minimum profit before executing arbitrage.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ca088f4-4c1a-4831-8a71-cc4f6eb95fb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ca088f4-4c1a-4831-8a71-cc4f6eb95fb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

